### PR TITLE
fix up eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,11 +3,7 @@ module.exports = {
     browser: true,
     es6: true
   },
-  extends: [
-    'eslint:recommended',
-    'plugin:import/errors',
-    'plugin:import/warnings'
-  ],
+  extends: ['eslint:recommended'],
   parserOptions: {
     ecmaFeatures: {
       experimentalObjectRestSpread: true,
@@ -16,12 +12,15 @@ module.exports = {
     },
     sourceType: 'module'
   },
-  plugins: ['react', 'import'],
+  plugins: ['react'],
   rules: {
+    'no-unused-vars': 1,
     indent: ['error', 2],
     'linebreak-style': ['error', 'unix'],
     quotes: ['error', 'single'],
     semi: ['error', 'always'],
-    'react/prop-types': 'error'
+    'react/prop-types': 'error',
+    'react/jsx-uses-vars': 2,
+    'react/jsx-uses-react': 2
   }
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   },
   "devDependencies": {
     "eslint": "^3.19.0",
-    "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-react": "^6.10.3",
     "prop-types": "^15.5.8",
     "react-scripts": "0.9.5"

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react'; // eslint-disable-line no-unused-vars
-import Title from './Components/Title'; // eslint-disable-line no-unused-vars
-import Todos from './Components/Todos'; // eslint-disable-line no-unused-vars
-import Input from './Components/Input'; // eslint-disable-line no-unused-vars
+import React, { Component } from 'react';
+import Title from './Components/Title';
+import Todos from './Components/Todos';
+import Input from './Components/Input';
 import uuid from 'uuid';
 import './App.css';
 

--- a/src/Components/Input.js
+++ b/src/Components/Input.js
@@ -1,4 +1,4 @@
-import React from 'react'; // eslint-disable-line no-unused-vars
+import React from 'react';
 import PropTypes from 'prop-types';
 
 const Input = props => {

--- a/src/Components/Title.js
+++ b/src/Components/Title.js
@@ -1,4 +1,4 @@
-import React from 'react'; // eslint-disable-line no-unused-vars
+import React from 'react';
 import PropTypes from 'prop-types';
 
 const Title = props => {

--- a/src/Components/TodoItem.js
+++ b/src/Components/TodoItem.js
@@ -1,4 +1,4 @@
-import React from 'react'; // eslint-disable-line no-unused-vars
+import React from 'react';
 import PropTypes from 'prop-types';
 
 const TodoItem = props => {

--- a/src/Components/Todos.js
+++ b/src/Components/Todos.js
@@ -1,6 +1,6 @@
-import React from 'react'; // eslint-disable-line no-unused-vars
+import React from 'react';
 import PropTypes from 'prop-types';
-import TodoItem from './TodoItem'; // eslint-disable-line no-unused-vars
+import TodoItem from './TodoItem';
 
 const Todos = props => {
   let todoItems;


### PR DESCRIPTION
just adds some eslint react rules so as to remove the inline rules with the import statements.

also changed `no-used-vars` to be a warning instead of an error, so it's less aggressive when dev-ving.